### PR TITLE
Fix index generation in build workflow

### DIFF
--- a/.github/workflows/build-pdfs.yml
+++ b/.github/workflows/build-pdfs.yml
@@ -81,15 +81,15 @@ jobs:
           </head>
           <body>
             <h1>📚 Apuntes de Bases de Datos</h1>' > build/index.html
-      
-          find build/$dir -type f \( -name "*.pdf" -o -name "*.html" \) -print0 | sort -z | while IFS= read -r -d '' file; do
+          echo '<ul>' >> build/index.html
+
+          find build -type f \( -name "*.pdf" -o -name "*.html" \) -not -name index.html -print0 | sort -z | while IFS= read -r -d '' file; do
             name=$(basename "$file")
             path="${file#build/}"
             echo "<li><a href=\"$path\">$name</a></li>" >> build/index.html
           done
+          echo '</ul>' >> build/index.html
 
-
-      
           echo '</body></html>' >> build/index.html
 
       - name: Deploy production


### PR DESCRIPTION
## Summary
- generate HTML index over entire build directory
- skip self-linking to index.html and wrap links in `<ul>`

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 200}, document-start: disable, truthy: disable, brackets: disable, empty-lines: disable}}' .github/workflows/build-pdfs.yml`
- `xmllint --html --noout build/index.html`
- `grep -n "index.html" build/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68c146b8eab4832d931a50d1da464361